### PR TITLE
fixed TextAnswerFormat requires validationRegEx

### DIFF
--- a/lib/src/answer_format/text_answer_format.dart
+++ b/lib/src/answer_format/text_answer_format.dart
@@ -10,13 +10,17 @@ class TextAnswerFormat implements AnswerFormat {
   final String hint;
 
   /// Regular expression by which the text gets validated
-  ///  e.g '^(?!\s*$).+' checks if the entered text is empty
+  /// default: '^(?!\s*$).+' that checks if the entered text is empty
+  /// to allow any type of an answer including an empty one;
+  /// set it explicitly to null.
+  ///
+  @JsonKey(defaultValue: '^(?!\s*\$).+')
   final String? validationRegEx;
 
   const TextAnswerFormat({
     this.maxLines,
     this.hint = '',
-    this.validationRegEx,
+    this.validationRegEx = '^(?!\s*\$).+',
   }) : super();
 
   factory TextAnswerFormat.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/answer_format/text_answer_format.g.dart
+++ b/lib/src/answer_format/text_answer_format.g.dart
@@ -10,7 +10,7 @@ TextAnswerFormat _$TextAnswerFormatFromJson(Map<String, dynamic> json) =>
     TextAnswerFormat(
       maxLines: json['maxLines'] as int?,
       hint: json['hint'] as String? ?? '',
-      validationRegEx: json['validationRegEx'] as String?,
+      validationRegEx: json['validationRegEx'] as String? ?? r'^(?!s*$).+',
     );
 
 Map<String, dynamic> _$TextAnswerFormatToJson(TextAnswerFormat instance) =>

--- a/lib/src/views/text_answer_view.dart
+++ b/lib/src/views/text_answer_view.dart
@@ -41,6 +41,8 @@ class _TextAnswerViewState extends State<TextAnswerView> {
       if (_textAnswerFormat.validationRegEx != null) {
         RegExp regExp = new RegExp(_textAnswerFormat.validationRegEx!);
         _isValid = regExp.hasMatch(text);
+      } else {
+        _isValid = true;
       }
     });
   }


### PR DESCRIPTION
fixed #40  

Before this fix, as described by @Joshua27:
- the `validationRegEx` field on `TextAnswerFormat` was `null` by default
- but when you input an answer in the field that was not getting to a valid state, which meant that
- you had to set the `validationRegEx` to something (e.g.` ".*"`) to be able to press Next in the survey

Proposed behaviour: an empty answer should not be accepted by default.

So after this fix:
- the `validationRegEx` field is set to `"^(?!\s*$).+"` by default
- if you want to allow an empty answer you would have to set `validationRegEx` to `null` explicitly
- the state of the `TextAnswerFormat` field will get validated in both cases