### PR TITLE
Added MultipleChoiceAutoCompleteAnswerView, other text field in MCQ answers

### DIFF
--- a/example/assets/example_json.json
+++ b/example/assets/example_json.json
@@ -1,8 +1,7 @@
 {
     "id": "123",
     "type": "navigable",
-    "rules": [
-        {
+    "rules": [{
             "type": "conditional",
             "triggerStepIdentifier": {
                 "id": "7"
@@ -53,8 +52,7 @@
             }
         }
     ],
-    "steps": [
-        {
+    "steps": [{
             "stepIdentifier": {
                 "id": "1"
             },
@@ -126,8 +124,7 @@
             "title": "Known allergies",
             "answerFormat": {
                 "type": "multiple",
-                "textChoices": [
-                    {
+                "textChoices": [{
                         "text": "Penicillin",
                         "value": "Penicillin"
                     },
@@ -155,8 +152,7 @@
             "text": "We are done, do you mind to tell us more about yourself?",
             "answerFormat": {
                 "type": "single",
-                "textChoices": [
-                    {
+                "textChoices": [{
                         "text": "Yes",
                         "value": "Yes"
                     },
@@ -196,6 +192,64 @@
         },
         {
             "stepIdentifier": {
+                "id": "12"
+            },
+            "type": "question",
+            "title": "Known allergies",
+            "answerFormat": {
+                "type": "multiple",
+                "otherField": true,
+                "textChoices": [{
+                        "text": "Penicillin",
+                        "value": "Penicillin"
+                    },
+                    {
+                        "text": "Latex",
+                        "value": "Latex"
+                    },
+                    {
+                        "text": "Pet",
+                        "value": "Pet"
+                    },
+                    {
+                        "text": "Pollen",
+                        "value": "Pollen"
+                    }
+                ]
+            }
+        },
+        {
+            "stepIdentifier": {
+                "id": "13"
+            },
+            "type": "question",
+            "title": "Medicines",
+            "answerFormat": {
+                "type": "multiple_auto_complete",
+                "otherField": true,
+                "textChoices": [{
+                        "text": "Penicillin",
+                        "value": "Penicillin"
+                    },
+                    {
+                        "text": "Latex",
+                        "value": "Latex"
+                    }
+
+                ],
+                "suggestions": [{
+                        "text": "Pet",
+                        "value": "Pet"
+                    },
+                    {
+                        "text": "Pollen",
+                        "value": "Pollen"
+                    }
+                ]
+            }
+        },
+        {
+            "stepIdentifier": {
                 "id": "10"
             },
             "type": "completion",
@@ -212,8 +266,7 @@
             "text": "What type of pet(s) do you have?",
             "answerFormat": {
                 "type": "multiple",
-                "textChoices": [
-                    {
+                "textChoices": [{
                         "text": "Dog",
                         "value": "Dog"
                     },

--- a/lib/src/answer_format/answer_format.dart
+++ b/lib/src/answer_format/answer_format.dart
@@ -4,6 +4,7 @@ import 'package:survey_kit/src/answer_format/boolean_answer_format.dart';
 import 'package:survey_kit/src/answer_format/date_answer_format.dart';
 import 'package:survey_kit/src/answer_format/integer_answer_format.dart';
 import 'package:survey_kit/src/answer_format/double_answer_format.dart';
+import 'package:survey_kit/src/answer_format/multiple_choice_auto_complete_answer_format.dart';
 import 'package:survey_kit/src/answer_format/multiple_double_answer_format.dart';
 import 'package:survey_kit/src/answer_format/multiple_choice_answer_format.dart';
 import 'package:survey_kit/src/answer_format/scale_answer_format.dart';
@@ -33,6 +34,8 @@ abstract class AnswerFormat {
         return MultipleChoiceAnswerFormat.fromJson(json);
       case 'multiple_double':
         return MultipleDoubleAnswerFormat.fromJson(json);
+      case 'multiple_auto_complete':
+        return MultipleChoiceAutoCompleteAnswerFormat.fromJson(json);
       case 'scale':
         return ScaleAnswerFormat.fromJson(json);
       case 'time':

--- a/lib/src/answer_format/multiple_choice_answer_format.dart
+++ b/lib/src/answer_format/multiple_choice_answer_format.dart
@@ -9,10 +9,13 @@ class MultipleChoiceAnswerFormat implements AnswerFormat {
   final List<TextChoice> textChoices;
   @JsonKey(defaultValue: const [])
   final List<TextChoice> defaultSelection;
+  @JsonKey(defaultValue: false)
+  final bool otherField;
 
   const MultipleChoiceAnswerFormat({
     required this.textChoices,
     this.defaultSelection = const [],
+    this.otherField = false,
   }) : super();
 
   factory MultipleChoiceAnswerFormat.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/answer_format/multiple_choice_answer_format.g.dart
+++ b/lib/src/answer_format/multiple_choice_answer_format.g.dart
@@ -16,6 +16,7 @@ MultipleChoiceAnswerFormat _$MultipleChoiceAnswerFormatFromJson(
               ?.map((e) => TextChoice.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],
+      otherField: json['otherField'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$MultipleChoiceAnswerFormatToJson(
@@ -23,4 +24,5 @@ Map<String, dynamic> _$MultipleChoiceAnswerFormatToJson(
     <String, dynamic>{
       'textChoices': instance.textChoices,
       'defaultSelection': instance.defaultSelection,
+      'otherField': instance.otherField,
     };

--- a/lib/src/answer_format/multiple_choice_auto_complete_answer_format.dart
+++ b/lib/src/answer_format/multiple_choice_auto_complete_answer_format.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:survey_kit/src/answer_format/answer_format.dart';
+import 'package:survey_kit/src/answer_format/text_choice.dart';
+
+part 'multiple_choice_auto_complete_answer_format.g.dart';
+
+@JsonSerializable()
+class MultipleChoiceAutoCompleteAnswerFormat implements AnswerFormat {
+  final List<TextChoice> textChoices;
+  @JsonKey(defaultValue: const [])
+  final List<TextChoice> defaultSelection;
+  @JsonKey(defaultValue: const [])
+  final List<TextChoice> suggestions;
+  @JsonKey(defaultValue: false)
+  final bool otherField;
+
+  const MultipleChoiceAutoCompleteAnswerFormat({
+    required this.textChoices,
+    this.defaultSelection = const [],
+    this.suggestions = const [],
+    this.otherField = false,
+  }) : super();
+
+  factory MultipleChoiceAutoCompleteAnswerFormat.fromJson(
+          Map<String, dynamic> json) =>
+      _$MultipleChoiceAutoCompleteAnswerFormatFromJson(json);
+  Map<String, dynamic> toJson() =>
+      _$MultipleChoiceAutoCompleteAnswerFormatToJson(this);
+}

--- a/lib/src/answer_format/multiple_choice_auto_complete_answer_format.g.dart
+++ b/lib/src/answer_format/multiple_choice_auto_complete_answer_format.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'multiple_choice_auto_complete_answer_format.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MultipleChoiceAutoCompleteAnswerFormat
+    _$MultipleChoiceAutoCompleteAnswerFormatFromJson(
+            Map<String, dynamic> json) =>
+        MultipleChoiceAutoCompleteAnswerFormat(
+          textChoices: (json['textChoices'] as List<dynamic>)
+              .map((e) => TextChoice.fromJson(e as Map<String, dynamic>))
+              .toList(),
+          defaultSelection: (json['defaultSelection'] as List<dynamic>?)
+                  ?.map((e) => TextChoice.fromJson(e as Map<String, dynamic>))
+                  .toList() ??
+              [],
+          suggestions: (json['suggestions'] as List<dynamic>?)
+                  ?.map((e) => TextChoice.fromJson(e as Map<String, dynamic>))
+                  .toList() ??
+              [],
+          otherField: json['otherField'] as bool? ?? false,
+        );
+
+Map<String, dynamic> _$MultipleChoiceAutoCompleteAnswerFormatToJson(
+        MultipleChoiceAutoCompleteAnswerFormat instance) =>
+    <String, dynamic>{
+      'textChoices': instance.textChoices,
+      'defaultSelection': instance.defaultSelection,
+      'suggestions': instance.suggestions,
+      'otherField': instance.otherField,
+    };

--- a/lib/src/result/question/multiple_choice_question_result.dart
+++ b/lib/src/result/question/multiple_choice_question_result.dart
@@ -22,7 +22,8 @@ class MultipleChoiceQuestionResult extends QuestionResult<List<TextChoice>?> {
           result: result,
         );
 
-  factory MultipleChoiceQuestionResult.fromJson(Map<String, dynamic> json) => _$MultipleChoiceQuestionResultFromJson(json);
+  factory MultipleChoiceQuestionResult.fromJson(Map<String, dynamic> json) =>
+      _$MultipleChoiceQuestionResultFromJson(json);
 
   Map<String, dynamic> toJson() => _$MultipleChoiceQuestionResultToJson(this);
 

--- a/lib/src/result/step_result.dart
+++ b/lib/src/result/step_result.dart
@@ -24,10 +24,11 @@ class StepResult extends Result {
   @_Converter()
   final List<QuestionResult> results;
 
-  StepResult({required Identifier? id,
-    required DateTime startDate,
-    required DateTime endDate,
-    required this.results})
+  StepResult(
+      {required Identifier? id,
+      required DateTime startDate,
+      required DateTime endDate,
+      required this.results})
       : super(id: id, startDate: startDate, endDate: endDate);
 
   factory StepResult.fromQuestion({required QuestionResult questionResult}) {
@@ -79,6 +80,10 @@ class _Converter implements JsonConverter<List<QuestionResult>, Object> {
       } else if (qr is MultipleDoubleQuestionResult) {
         final qrJson = qr.toJson();
         qrJson['type'] = (MultipleDoubleQuestionResult).toString();
+        allQuestionResultsEncoded.add(qrJson);
+      } else if (qr is MultipleChoiceQuestionResult) {
+        final qrJson = qr.toJson();
+        qrJson['type'] = (MultipleChoiceQuestionResult).toString();
         allQuestionResultsEncoded.add(qrJson);
       } else if (qr is ScaleQuestionResult) {
         final qrJson = qr.toJson();

--- a/lib/src/steps/predefined_steps/question_step.dart
+++ b/lib/src/steps/predefined_steps/question_step.dart
@@ -6,6 +6,7 @@ import 'package:survey_kit/src/answer_format/date_answer_format.dart';
 import 'package:survey_kit/src/answer_format/double_answer_format.dart';
 import 'package:survey_kit/src/answer_format/integer_answer_format.dart';
 import 'package:survey_kit/src/answer_format/multiple_choice_answer_format.dart';
+import 'package:survey_kit/src/answer_format/multiple_choice_auto_complete_answer_format.dart';
 import 'package:survey_kit/src/answer_format/multiple_double_answer_format.dart';
 import 'package:survey_kit/src/answer_format/scale_answer_format.dart';
 import 'package:survey_kit/src/answer_format/single_choice_answer_format.dart';
@@ -26,6 +27,7 @@ import 'package:survey_kit/src/views/boolean_answer_view.dart';
 import 'package:survey_kit/src/views/date_answer_view.dart';
 import 'package:survey_kit/src/views/integer_answer_view.dart';
 import 'package:survey_kit/src/views/double_answer_view.dart';
+import 'package:survey_kit/src/views/multiple_auto_complete_answer_view.dart';
 import 'package:survey_kit/src/views/multiple_choice_answer_view.dart';
 import 'package:survey_kit/src/views/multiple_double_answer_view.dart';
 import 'package:survey_kit/src/views/scale_answer_view.dart';
@@ -128,6 +130,12 @@ class QuestionStep extends Step {
           key: key,
           questionStep: this,
           result: questionResult as MultipleDoubleQuestionResult?,
+        );
+      case MultipleChoiceAutoCompleteAnswerFormat:
+        return MultipleChoiceAutoCompleteAnswerView(
+          key: key,
+          questionStep: this,
+          result: questionResult as MultipleChoiceQuestionResult?,
         );
       default:
         throw AnswerFormatNotDefinedException();

--- a/lib/src/views/multiple_auto_complete_answer_view.dart
+++ b/lib/src/views/multiple_auto_complete_answer_view.dart
@@ -1,0 +1,204 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:survey_kit/src/answer_format/multiple_choice_auto_complete_answer_format.dart';
+import 'package:survey_kit/survey_kit.dart';
+
+class MultipleChoiceAutoCompleteAnswerView extends StatefulWidget {
+  final QuestionStep questionStep;
+  final MultipleChoiceQuestionResult? result;
+  const MultipleChoiceAutoCompleteAnswerView({
+    Key? key,
+    required this.questionStep,
+    this.result,
+  }) : super(key: key);
+
+  @override
+  State<MultipleChoiceAutoCompleteAnswerView> createState() =>
+      _MultipleChoiceAutoCompleteAnswerViewState();
+}
+
+class _MultipleChoiceAutoCompleteAnswerViewState
+    extends State<MultipleChoiceAutoCompleteAnswerView> {
+  late final DateTime _startDateTime;
+  late final MultipleChoiceAutoCompleteAnswerFormat _multipleChoiceAnswer;
+
+  List<TextChoice> _selectedChoices = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _multipleChoiceAnswer = widget.questionStep.answerFormat
+        as MultipleChoiceAutoCompleteAnswerFormat;
+    _selectedChoices =
+        widget.result?.result ?? _multipleChoiceAnswer.defaultSelection;
+    _startDateTime = DateTime.now();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StepView(
+      step: widget.questionStep,
+      resultFunction: () => MultipleChoiceQuestionResult(
+        id: widget.questionStep.stepIdentifier,
+        startDate: _startDateTime,
+        endDate: DateTime.now(),
+        valueIdentifier:
+            _selectedChoices.map((choices) => choices.value).join(','),
+        result: _selectedChoices,
+      ),
+      isValid: widget.questionStep.isOptional || _selectedChoices.isNotEmpty,
+      title: widget.questionStep.title.isNotEmpty
+          ? Text(
+              widget.questionStep.title,
+              style: Theme.of(context).textTheme.headline2,
+              textAlign: TextAlign.center,
+            )
+          : widget.questionStep.content,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14.0),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(bottom: 32.0),
+              child: Text(
+                widget.questionStep.text,
+                style: Theme.of(context).textTheme.bodyText2,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            Column(
+              children: [
+                Autocomplete<TextChoice>(
+                  fieldViewBuilder: (context, textEditingController, focusNode,
+                          onFieldSubmitted) =>
+                      TextField(
+                    controller: textEditingController,
+                    focusNode: focusNode,
+                    decoration:
+                        InputDecoration(labelText: 'Search more medicines...'),
+                    onSubmitted: (v) {
+                      onFieldSubmitted();
+                    },
+                  ),
+                  displayStringForOption: (tc) => tc.text,
+                  optionsBuilder: (textEditingValue) {
+                    if (textEditingValue.text == '') {
+                      return const Iterable<TextChoice>.empty();
+                    }
+
+                    return _multipleChoiceAnswer.suggestions.where((element) =>
+                        element.text
+                            .toLowerCase()
+                            .contains(textEditingValue.text.toLowerCase()));
+                  },
+                  onSelected: (tc) {
+                    setState(
+                      () {
+                        if (_selectedChoices.contains(tc)) {
+                          _selectedChoices.remove(tc);
+                        } else {
+                          _selectedChoices = [..._selectedChoices, tc];
+                        }
+                      },
+                    );
+                  },
+                ),
+                SizedBox(
+                  height: 32,
+                ),
+                Divider(
+                  color: Colors.grey,
+                ),
+                ..._multipleChoiceAnswer.textChoices
+                    .map(
+                      (TextChoice tc) => SelectionListTile(
+                        text: tc.text,
+                        onTap: () {
+                          setState(
+                            () {
+                              if (_selectedChoices.contains(tc)) {
+                                _selectedChoices.remove(tc);
+                              } else {
+                                _selectedChoices = [..._selectedChoices, tc];
+                              }
+                            },
+                          );
+                        },
+                        isSelected: _selectedChoices.contains(tc),
+                      ),
+                    )
+                    .toList(),
+                ..._selectedChoices
+                    .where((element) =>
+                        !_multipleChoiceAnswer.textChoices.contains(element))
+                    .map(
+                      (TextChoice tc) => SelectionListTile(
+                        text: tc.text,
+                        onTap: () {
+                          setState(
+                            () {
+                              if (_selectedChoices.contains(tc)) {
+                                _selectedChoices.remove(tc);
+                              } else {
+                                _selectedChoices = [..._selectedChoices, tc];
+                              }
+                            },
+                          );
+                        },
+                        isSelected: _selectedChoices.contains(tc),
+                      ),
+                    )
+                    .toList(),
+                if (_multipleChoiceAnswer.otherField) ...[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 14.0),
+                    child: ListTile(
+                      title: TextField(
+                        onChanged: (v) {
+                          int? currentIndex;
+                          final otherTextChoice = _selectedChoices
+                              .firstWhereIndexedOrNull((index, element) {
+                            final isOtherField = element.text == 'Other';
+
+                            if (isOtherField) {
+                              currentIndex = index;
+                            }
+
+                            return isOtherField;
+                          });
+
+                          setState(() {
+                            if (v.isEmpty && otherTextChoice != null) {
+                              _selectedChoices.remove(otherTextChoice);
+                            } else if (v.isNotEmpty) {
+                              final updatedTextChoice =
+                                  TextChoice(text: 'Other', value: v);
+                              if (otherTextChoice == null) {
+                                _selectedChoices.add(updatedTextChoice);
+                              } else if (currentIndex != null) {
+                                _selectedChoices[currentIndex!] =
+                                    updatedTextChoice;
+                              }
+                            }
+                          });
+                        },
+                        decoration: InputDecoration(
+                          labelText: 'Other',
+                          labelStyle: Theme.of(context).textTheme.headline5,
+                          hintText: 'Write other information here',
+                        ),
+                      ),
+                    ),
+                  ),
+                  Divider(
+                    color: Colors.grey,
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/views/multiple_auto_complete_answer_view.dart
+++ b/lib/src/views/multiple_auto_complete_answer_view.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:survey_kit/src/answer_format/multiple_choice_auto_complete_answer_format.dart';
 import 'package:survey_kit/survey_kit.dart';
 
@@ -79,6 +80,48 @@ class _MultipleChoiceAutoCompleteAnswerViewState
                     onSubmitted: (v) {
                       onFieldSubmitted();
                     },
+                  ),
+                  optionsViewBuilder: (context, onSelected, options) => Align(
+                    alignment: Alignment.topLeft,
+                    child: Material(
+                      elevation: 4.0,
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(maxHeight: 200),
+                        child: ListView.builder(
+                          padding: EdgeInsets.zero,
+                          shrinkWrap: true,
+                          itemCount: options.length,
+                          itemBuilder: (BuildContext context, int index) {
+                            final option = options.elementAt(index);
+                            return InkWell(
+                              onTap: () {
+                                onSelected(option);
+                              },
+                              child: Builder(builder: (BuildContext context) {
+                                final bool highlight =
+                                    AutocompleteHighlightedOption.of(context) ==
+                                        index;
+                                if (highlight) {
+                                  SchedulerBinding.instance
+                                      .addPostFrameCallback(
+                                          (Duration timeStamp) {
+                                    Scrollable.ensureVisible(context,
+                                        alignment: 0.5);
+                                  });
+                                }
+                                return Container(
+                                  color: highlight
+                                      ? Theme.of(context).focusColor
+                                      : null,
+                                  padding: const EdgeInsets.all(16.0),
+                                  child: Text(option.text),
+                                );
+                              }),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
                   ),
                   displayStringForOption: (tc) => tc.text,
                   optionsBuilder: (textEditingValue) {

--- a/lib/src/views/multiple_auto_complete_answer_view.dart
+++ b/lib/src/views/multiple_auto_complete_answer_view.dart
@@ -73,6 +73,7 @@ class _MultipleChoiceAutoCompleteAnswerViewState
                 _AutoComplete(
                   suggestions: _multipleChoiceAnswer.suggestions,
                   onSelected: onChoiceSelected,
+                  selectedChoices: _selectedChoices,
                 ),
                 SizedBox(
                   height: 32,
@@ -172,11 +173,12 @@ class _AutoComplete extends StatelessWidget {
     Key? key,
     required this.suggestions,
     required this.onSelected,
+    required this.selectedChoices,
   }) : super(key: key);
 
   final List<TextChoice> suggestions;
-
   final void Function(TextChoice) onSelected;
+  final List<TextChoice> selectedChoices;
 
   @override
   Widget build(BuildContext context) {
@@ -187,15 +189,25 @@ class _AutoComplete extends StatelessWidget {
         controller: textEditingController,
         focusNode: focusNode,
         decoration: InputDecoration(
-          labelText: 'Search',
-          hintText: 'Type here to search.',
-        ),
+            contentPadding: EdgeInsets.symmetric(horizontal: 32),
+            labelText: 'Search',
+            hintText: 'Type here to search',
+            suffixIcon: IconButton(
+              padding: EdgeInsets.zero,
+              icon: Icon(Icons.clear),
+              onPressed: () {
+                textEditingController.clear();
+              },
+            )),
         onSubmitted: (v) {
           onFieldSubmitted();
         },
       ),
-      optionsViewBuilder: (context, onSelected, options) =>
-          _OptionsViewBuilder(options: options, onSelected: onSelected),
+      optionsViewBuilder: (context, onSelected, options) => _OptionsViewBuilder(
+        options: options,
+        onSelected: onSelected,
+        selectedChoices: selectedChoices,
+      ),
       displayStringForOption: (tc) => tc.text,
       optionsBuilder: (textEditingValue) {
         if (textEditingValue.text == '') {
@@ -216,13 +228,15 @@ class _OptionsViewBuilder extends StatelessWidget {
     Key? key,
     required this.options,
     required this.onSelected,
+    required this.selectedChoices,
   }) : super(key: key);
 
   final Iterable<TextChoice> options;
   final void Function(TextChoice) onSelected;
+  final List<TextChoice> selectedChoices;
   @override
   Widget build(BuildContext context) => Align(
-        alignment: Alignment.topCenter,
+        alignment: Alignment.topLeft,
         child: Material(
           elevation: 4.0,
           textStyle: Theme.of(context).textTheme.bodyText1,
@@ -250,7 +264,14 @@ class _OptionsViewBuilder extends StatelessWidget {
                     return Container(
                       color: highlight ? Theme.of(context).focusColor : null,
                       padding: const EdgeInsets.all(16.0),
-                      child: Text(option.text),
+                      margin: EdgeInsets.only(right: 16),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(option.text),
+                          if (selectedChoices.contains(option)) Icon(Icons.done)
+                        ],
+                      ),
                     );
                   }),
                 );

--- a/lib/src/views/multiple_auto_complete_answer_view.dart
+++ b/lib/src/views/multiple_auto_complete_answer_view.dart
@@ -35,6 +35,7 @@ class _MultipleChoiceAutoCompleteAnswerViewState
     _startDateTime = DateTime.now();
   }
 
+  // TODO refactor the widgets and organize, DRY also
   @override
   Widget build(BuildContext context) {
     return StepView(

--- a/lib/src/views/multiple_choice_answer_view.dart
+++ b/lib/src/views/multiple_choice_answer_view.dart
@@ -130,6 +130,7 @@ class _MultipleChoiceAnswerView extends State<MultipleChoiceAnswerView> {
                           labelText: 'Other',
                           labelStyle: Theme.of(context).textTheme.headline5,
                           hintText: 'Write other information here',
+                          floatingLabelBehavior: FloatingLabelBehavior.always,
                         ),
                       ),
                     ),

--- a/lib/src/views/multiple_choice_answer_view.dart
+++ b/lib/src/views/multiple_choice_answer_view.dart
@@ -5,6 +5,7 @@ import 'package:survey_kit/src/views/widget/selection_list_tile.dart';
 import 'package:survey_kit/src/result/question/multiple_choice_question_result.dart';
 import 'package:survey_kit/src/steps/predefined_steps/question_step.dart';
 import 'package:survey_kit/src/views/widget/step_view.dart';
+import 'package:collection/collection.dart';
 
 class MultipleChoiceAnswerView extends StatefulWidget {
   final QuestionStep questionStep;
@@ -92,6 +93,51 @@ class _MultipleChoiceAnswerView extends State<MultipleChoiceAnswerView> {
                       ),
                     )
                     .toList(),
+                if (_multipleChoiceAnswer.otherField) ...[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 14.0),
+                    child: ListTile(
+                      title: TextField(
+                        onChanged: (v) {
+                          int? currentIndex;
+                          final otherTextChoice = _selectedChoices
+                              .firstWhereIndexedOrNull((index, element) {
+                            final isOtherField = element.text == 'Other';
+
+                            if (isOtherField) {
+                              currentIndex = index;
+                            }
+
+                            return isOtherField;
+                          });
+
+                          setState(() {
+                            if (v.isEmpty && otherTextChoice != null) {
+                              _selectedChoices.remove(otherTextChoice);
+                            } else if (v.isNotEmpty) {
+                              final updatedTextChoice =
+                                  TextChoice(text: 'Other', value: v);
+                              if (otherTextChoice == null) {
+                                _selectedChoices.add(updatedTextChoice);
+                              } else if (currentIndex != null) {
+                                _selectedChoices[currentIndex!] =
+                                    updatedTextChoice;
+                              }
+                            }
+                          });
+                        },
+                        decoration: InputDecoration(
+                          labelText: 'Other',
+                          labelStyle: Theme.of(context).textTheme.headline5,
+                          hintText: 'Write other information here',
+                        ),
+                      ),
+                    ),
+                  ),
+                  Divider(
+                    color: Colors.grey,
+                  ),
+                ],
               ],
             ),
           ],

--- a/lib/src/views/widget/survey_app_bar.dart
+++ b/lib/src/views/widget/survey_app_bar.dart
@@ -23,10 +23,7 @@ class SurveyAppBar extends StatelessWidget {
     return AppBar(
       leading: _canGoBack
           ? appBarConfiguration.leading ??
-              IconButton(
-                icon: Icon(
-                  Icons.arrow_back,
-                ),
+              BackButton(
                 onPressed: () {
                   surveyController.stepBack(
                     context: context,

--- a/lib/src/views/widget/survey_app_bar.dart
+++ b/lib/src/views/widget/survey_app_bar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:survey_kit/src/configuration/app_bar_configuration.dart';
 import 'package:survey_kit/src/controller/survey_controller.dart';
 import 'package:survey_kit/src/widget/survey_progress.dart';
@@ -15,13 +14,13 @@ class SurveyAppBar extends StatelessWidget {
   });
 
   @override
-  PlatformAppBar build(BuildContext context) {
+  AppBar build(BuildContext context) {
     final _showProgress =
         appBarConfiguration.showProgress ?? context.read<bool>();
     final _canGoBack = appBarConfiguration.canBack ?? true;
 
     final surveyController = controller ?? context.read<SurveyController>();
-    return PlatformAppBar(
+    return AppBar(
       leading: _canGoBack
           ? appBarConfiguration.leading ??
               IconButton(
@@ -36,7 +35,7 @@ class SurveyAppBar extends StatelessWidget {
               )
           : Container(),
       title: _showProgress ? SurveyProgress() : SizedBox.shrink(),
-      trailingActions: [
+      actions: [
         TextButton(
           child: appBarConfiguration.trailing ??
               Text(


### PR DESCRIPTION
- Added `MultipleChoiceAutoCompleteAnswerView` where developers can pass list of auto complete suggestions, helpful for showing a long list of answers where we can show important choices in the `textChoices` field and the rest in `suggestions`.
- Added `otherField` = true/false/null for both `MultipleChoiceAutoCompleteAnswerView` and `MultipleChoiceAnswerView`, this will enable a TextField to input customized answers which is not in the `textChoices` list.

Additional small updates:
- Replaced `PlatformAppBar` with Flutter default `AppBar` for consistency.
- Replaced `IconButton` for navigating back to Flutter default `BackButton` widget.

Example Json format: 
```Json
{
            "stepIdentifier": {
                "id": "13"
            },
            "type": "question",
            "title": "Medicines",
            "answerFormat": {
                "type": "multiple_auto_complete",
                "otherField": true,
                "textChoices": [{
                        "text": "Penicillin",
                        "value": "Penicillin"
                    },
                    {
                        "text": "Latex",
                        "value": "Latex"
                    }

                ],
                "suggestions": [{
                        "text": "Pet",
                        "value": "Pet"
                    },
                    {
                        "text": "Pollen",
                        "value": "Pollen"
                    }
                ]
            }
        },
```
#### Demo:
![auto_complete](https://user-images.githubusercontent.com/113627718/200746735-0f978232-5dfe-4f73-ab18-5aa51d8da7d7.gif)

